### PR TITLE
General IMessagePropagator refactoring

### DIFF
--- a/Editor/Backend.Common/Backend.Common.csproj
+++ b/Editor/Backend.Common/Backend.Common.csproj
@@ -8,8 +8,4 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0" />
-  </ItemGroup>
-
 </Project>

--- a/Editor/Backend.Common/MessagePropagator/BackgroundTaskDispatcher.cs
+++ b/Editor/Backend.Common/MessagePropagator/BackgroundTaskDispatcher.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Backend.Common.MessagePropagator
+{
+    public class BackgroundTaskDispatcher : ITaskDispatcher
+    {
+        public async Task Dispatch(Func<Task> task)
+        {
+            await Task.Run(task);
+        }
+
+        public async Task Dispatch<T>(Func<T, Task> task, T parameter)
+        {
+            await Task.Run(async () => await task.Invoke(parameter));
+        }
+    }
+}

--- a/Editor/Backend.Common/MessagePropagator/CurrentThreadTaskDispatcher.cs
+++ b/Editor/Backend.Common/MessagePropagator/CurrentThreadTaskDispatcher.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Backend.Common.MessagePropagator
+{
+    public class CurrentThreadTaskDispatcher : ITaskDispatcher
+    {
+        public async Task Dispatch(Func<Task> task)
+        {
+            await task();
+        }
+
+        public async Task Dispatch<T>(Func<T, Task> task, T parameter)
+        {
+            await task(parameter);
+        }
+    }
+}

--- a/Editor/Backend.Common/MessagePropagator/IMessageExceptionHandler.cs
+++ b/Editor/Backend.Common/MessagePropagator/IMessageExceptionHandler.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Backend.Common.MessagePropagator
+{
+    public interface IMessageExceptionHandler
+    {
+        public Task OnExceptionRaised(Exception e);
+    }
+}

--- a/Editor/Backend.Common/MessagePropagator/IMessagePropagator.cs
+++ b/Editor/Backend.Common/MessagePropagator/IMessagePropagator.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Backend.Common.MessagePropagator
+﻿namespace Backend.Common.MessagePropagator
 {
     public interface IMessagePropagator
     {

--- a/Editor/Backend.Common/MessagePropagator/ISubscriptionToken.cs
+++ b/Editor/Backend.Common/MessagePropagator/ISubscriptionToken.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Backend.Common.MessagePropagator
 {
     public interface ISubscriptionToken
     {
 
-        Task Invoke(object[] paramz);
+        Task Invoke(object[] p);
 
+        void Unsubscribe();
     }
 }

--- a/Editor/Backend.Common/MessagePropagator/ITaskDispatcher.cs
+++ b/Editor/Backend.Common/MessagePropagator/ITaskDispatcher.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Backend.Common.MessagePropagator
+{
+    public interface ITaskDispatcher
+    {
+        public Task Dispatch(Func<Task> task);
+
+        public Task Dispatch<T>(Func<T, Task> task, T parameter);
+    }
+}

--- a/Editor/Backend.Common/MessagePropagator/LogConsoleMessageExceptionHandler.cs
+++ b/Editor/Backend.Common/MessagePropagator/LogConsoleMessageExceptionHandler.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Backend.Common.MessagePropagator
+{
+    public class LogConsoleMessageExceptionHandler : IMessageExceptionHandler
+    {
+        public Task OnExceptionRaised(Exception e)
+        {
+            Console.WriteLine(e.Message);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Editor/Backend.Common/MessagePropagator/MessagePropagator.cs
+++ b/Editor/Backend.Common/MessagePropagator/MessagePropagator.cs
@@ -1,36 +1,60 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Backend.Common.MessagePropagator
 {
     public class MessagePropagator : IMessagePropagator
     {
+        public MessagePropagator(IMessageExceptionHandler messageExceptionHandler)
+        {
+            _messageExceptionHandler = messageExceptionHandler;
+            
+            RegisterDefaultTaskDispatchers();
+        }
+
+        public void RegisterTaskDispatcher(ThreadHandler threadHandler, ITaskDispatcher taskDispatcher)
+        {
+            _taskDispatchers.Add(threadHandler, taskDispatcher);
+        }
+
         public T GetMessage<T>() where T : MessageBase, new()
         {
             T message = null;
 
-            lock(_Messages)
+            lock(_messages)
             {
-                if(!_Messages.ContainsKey(typeof(T)))
+                if(!_messages.ContainsKey(typeof(T)))
                 {
+                    // Create the new Message
                     message = new T();
 
-                    _Messages.Add(typeof(T), message);
+                    // Register the stuff it needs
+                    message.TaskDispatchers = new Dictionary<ThreadHandler, ITaskDispatcher>(_taskDispatchers);
+                    message.MessageExceptionHandler = _messageExceptionHandler;
+
+                    // Keep it around for next time.
+                    _messages.Add(typeof(T), message);
                 }
                 else
                 {
-                    message = _Messages[typeof(T)] as T;
+                    // Previously created
+                    message = _messages[typeof(T)] as T;
                 }
             }
 
             return message;
         }
+        
+        private void RegisterDefaultTaskDispatchers()
+        {
+            RegisterTaskDispatcher(ThreadHandler.Default, new CurrentThreadTaskDispatcher());
+            RegisterTaskDispatcher(ThreadHandler.Background, new BackgroundTaskDispatcher());
+        }
 
+        private readonly Hashtable _messages = new Hashtable();
+        private IMessageExceptionHandler _messageExceptionHandler;
 
-        private Hashtable _Messages = new Hashtable();
+        private Dictionary<ThreadHandler, ITaskDispatcher> _taskDispatchers =
+            new Dictionary<ThreadHandler, ITaskDispatcher>();
     }
 }

--- a/Editor/Backend.Common/MessagePropagator/ThreadHandler.cs
+++ b/Editor/Backend.Common/MessagePropagator/ThreadHandler.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Backend.Common.MessagePropagator
+﻿namespace Backend.Common.MessagePropagator
 {
     public enum ThreadHandler
     {

--- a/Editor/Backend.UI/MessagePropagator/AvaloniaUITaskDispatcher.cs
+++ b/Editor/Backend.UI/MessagePropagator/AvaloniaUITaskDispatcher.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using Backend.Common.MessagePropagator;
+
+namespace Backend.UI.MessagePropagator
+{
+    public class AvaloniaUITaskDispatcher : ITaskDispatcher
+    {
+        public async Task Dispatch(Func<Task> task)
+        {
+            await _dispatcher.InvokeAsync(task);
+        }
+
+        public async Task Dispatch<T>(Func<T, Task> task, T parameter)
+        {
+            await _dispatcher.InvokeAsync(async () => await task(parameter));
+        }
+
+        private readonly Dispatcher _dispatcher = Dispatcher.UIThread;
+    }
+}

--- a/Editor/Backend.UI/Tools/BaseToolWindow.cs
+++ b/Editor/Backend.UI/Tools/BaseToolWindow.cs
@@ -1,14 +1,16 @@
-﻿using Backend.Common.MessagePropagator;
+﻿using System;
+using System.Collections.Generic;
+using Backend.Common.MessagePropagator;
 using Dock.Model.Controls;
 using System.Reflection;
 
 namespace Backend.UI.Tools
 {
-    public class BaseToolWindow : Tool
+    public class BaseToolWindow : Tool, IDisposable
     {
         protected BaseToolWindow(IMessagePropagator messagePropagator)
         {
-            _MessagePropagator = messagePropagator;
+            _messagePropagator = messagePropagator;
 
             ToolWindowAttribute toolWindowAttribute =
                 this.GetType().GetCustomAttribute<ToolWindowAttribute>();
@@ -17,11 +19,42 @@ namespace Backend.UI.Tools
             Title = toolWindowAttribute.DisplayName;
         }
 
-        public BaseToolWindow(BaseToolWindow copy)
+        protected BaseToolWindow(BaseToolWindow copy)
         {
-            _MessagePropagator = copy._MessagePropagator;
+            _messagePropagator = copy._messagePropagator;
+        }
+        
+        /// <summary>
+        /// This handles the Unregistering of Message Subscribers when this VM is destroyed.
+        /// </summary>
+        /// <param name="subscriptionToken">The ISubscriptionToken to unregister</param>
+        protected void HandleSubscriptionOnDispose(ISubscriptionToken subscriptionToken)
+        {
+            _subscriptionTokens.Add(subscriptionToken);
         }
 
-        protected IMessagePropagator _MessagePropagator;
+        protected virtual void OnDisposal() { }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                OnDisposal();
+                
+                foreach (ISubscriptionToken subscriptionToken in _subscriptionTokens)
+                {
+                    subscriptionToken.Unsubscribe();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        
+        protected readonly IMessagePropagator _messagePropagator;
+        private readonly List<ISubscriptionToken> _subscriptionTokens = new();
     }
 }

--- a/Editor/Editor/App.xaml.cs
+++ b/Editor/Editor/App.xaml.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Backend.Common.MessagePropagator;
+using Backend.UI.MessagePropagator;
 using Dock.Model;
 using Editor.Dock;
 using Editor.ViewModels;
@@ -56,7 +57,10 @@ namespace Editor
 
         private void CreateDependencies()
         {
-            _messagePropagator = new MessagePropagator();
+            MessagePropagator messagePropagator = new MessagePropagator(new LogConsoleMessageExceptionHandler());
+            messagePropagator.RegisterTaskDispatcher(ThreadHandler.UIThread, new AvaloniaUITaskDispatcher());
+
+            _messagePropagator = messagePropagator;
 
             _dependencies.Add(typeof(IMessagePropagator), _messagePropagator);
         }

--- a/Editor/Tool.Example/Document/ExampleDocumentViewModel.cs
+++ b/Editor/Tool.Example/Document/ExampleDocumentViewModel.cs
@@ -37,7 +37,7 @@ namespace Tool.Example.Document
 
         private async Task FireTestMessage()
         {
-            await _MessagePropagator.GetMessage<ExampleTestMessage>().Publish(_testMessage);
+            await _messagePropagator.GetMessage<ExampleTestMessage>().Publish(_testMessage);
         }
 
         private void CreateCommands()

--- a/Editor/Tool.Example/Floating/ExampleFloatingViewModel.cs
+++ b/Editor/Tool.Example/Floating/ExampleFloatingViewModel.cs
@@ -33,7 +33,7 @@ namespace Tool.Example.Floating
 
         private void RegisterMessages()
         {
-            _MessagePropagator.GetMessage<ExampleTestMessage>()
+            _messagePropagator.GetMessage<ExampleTestMessage>()
                 .Subscribe(OnExampleTestMessage, ThreadHandler.UIThread);
 
         }


### PR DESCRIPTION
Features:
* Refactored the IMessagePropagator to not be tied to a specific UI framework via the ITaskDispatcher interface.
* Refactored IMessagePropagator to catch exceptions so when an exception is raised, it will not affect other listeners or leave the Publish() of the message in an undefined state.
* IMessagePropagator has the ability to change out the Exception handler via an interface IMessageExceptionHandler
* ISubscriptionTokens now can unregister themselves via the Unsubscibe() function.
* BaseToolWindow View Model (VM) now can handle unregistering the Subscription Tokens when the VM is disposed of. HandleSubscriptionOnDispose() from the derived VM will keep track of this.